### PR TITLE
Add delegate to allow for more ViewGroup expandable layouts

### DIFF
--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableFrameLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableFrameLayout.java
@@ -1,50 +1,17 @@
 package com.github.aakira.expandablelayout;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.animation.TimeInterpolator;
-import android.animation.ValueAnimator;
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.os.Build;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
-import android.view.View;
-import android.view.animation.LinearInterpolator;
 import android.widget.FrameLayout;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayout {
 
-    private int duration;
-    private boolean isExpanded;
-    private TimeInterpolator interpolator = new LinearInterpolator();
-    private int orientation;
-    /**
-     * You cannot define {@link #isExpanded}, {@link #defaultChildIndex}
-     * and {@link #defaultChildPosition} at the same time.
-     * {@link #defaultChildPosition} has priority over {@link #isExpanded}
-     * and {@link #defaultChildIndex} if you set them at the same time.
-     */
-    private int defaultChildIndex;
-    private int defaultChildPosition;
-    /**
-     * The close position is width from left of layout if orientation is horizontal.
-     * The close position is height from top of layout if orientation is vertical.
-     */
-    private int closePosition = 0;
-
-    private ExpandableLayoutListener listener;
-    private ExpandableSavedState savedState;
-    private int layoutSize = 0;
-    private boolean isArranged = false;
-    private boolean isCalculatedSize = false;
-    private boolean isAnimating = false;
-    private List<Integer> childPositionList = new ArrayList<>();
+    private ExpandableLayoutDelegate mDelegate;
 
     public ExpandableFrameLayout(final Context context) {
         this(context, null);
@@ -68,84 +35,19 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
     }
 
     private void init(final Context context, final AttributeSet attrs, final int defStyleAttr) {
-        final TypedArray a = context.obtainStyledAttributes(
-                attrs, R.styleable.expandableLayout, defStyleAttr, 0);
-        duration = a.getInteger(R.styleable.expandableLayout_ael_duration, DEFAULT_DURATION);
-        isExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
-        orientation = a.getInteger(R.styleable.expandableLayout_ael_orientation, VERTICAL);
-        defaultChildIndex = a.getInteger(R.styleable.expandableLayout_ael_defaultChildIndex,
-                Integer.MAX_VALUE);
-        defaultChildPosition = a.getInteger(R.styleable.expandableLayout_ael_defaultPosition,
-                Integer.MIN_VALUE);
-        final int interpolatorType = a.getInteger(R.styleable.expandableLayout_ael_interpolator,
-                Utils.LINEAR_INTERPOLATOR);
-        interpolator = Utils.createInterpolator(interpolatorType);
-        a.recycle();
+        mDelegate = new ExpandableLayoutDelegate(this);
+        mDelegate.init(context, attrs, defStyleAttr);
     }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-
-        if (!isCalculatedSize) {
-            // calculate this layout size
-            childPositionList.clear();
-            int childSize;
-            int childMargin;
-            int sumSize = 0;
-            View view;
-            LayoutParams params;
-            for (int i = 0; i < getChildCount(); i++) {
-                view = getChildAt(i);
-                params = (LayoutParams) view.getLayoutParams();
-
-                childSize = isVertical()
-                        ? view.getMeasuredHeight() : view.getMeasuredWidth();
-                childMargin = isVertical()
-                        ? params.topMargin + params.bottomMargin
-                        : params.leftMargin + params.rightMargin;
-                if (0 < i) {
-                    sumSize = childPositionList.get(i - 1);
-                }
-                childPositionList.add(sumSize + childSize + childMargin);
-            }
-            layoutSize = childPositionList.get(childPositionList.size() - 1);
-
-            if (0 < layoutSize) {
-                isCalculatedSize = true;
-            }
-        }
-
-        if (isArranged) {
-            return;
-        }
-
-        if (isExpanded) {
-            setLayoutSize(layoutSize);
-        } else {
-            setLayoutSize(closePosition);
-        }
-        final int childNumbers = childPositionList.size();
-        if (childNumbers > defaultChildIndex && childNumbers > 0) {
-            moveChild(defaultChildIndex, 0, null);
-        }
-        if (defaultChildPosition > 0 && layoutSize >= defaultChildPosition && layoutSize > 0) {
-            move(defaultChildPosition, 0, null);
-        }
-        isArranged = true;
-
-        if (savedState == null) {
-            return;
-        }
-        setLayoutSize(savedState.getSize());
+        mDelegate.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 
     @Override
     protected Parcelable onSaveInstanceState() {
-        final Parcelable parcelable = super.onSaveInstanceState();
-        final ExpandableSavedState ss = new ExpandableSavedState(parcelable);
-        ss.setSize(getCurrentPosition());
-        return ss;
+        return mDelegate.onSaveInstanceState(super.onSaveInstanceState());
     }
 
     @Override
@@ -157,7 +59,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
 
         final ExpandableSavedState ss = (ExpandableSavedState) state;
         super.onRestoreInstanceState(ss.getSuperState());
-        savedState = ss;
+        mDelegate.onRestoreInstanceState(ss);
     }
 
     /**
@@ -165,7 +67,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void setListener(@NonNull ExpandableLayoutListener listener) {
-        this.listener = listener;
+        mDelegate.setListener(listener);
     }
 
     /**
@@ -173,11 +75,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void toggle() {
-        if (closePosition < getCurrentPosition()) {
-            collapse();
-        } else {
-            expand();
-        }
+        mDelegate.toggle();
     }
 
     /**
@@ -185,11 +83,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void expand() {
-        if (isAnimating) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), layoutSize,
-                duration, interpolator).start();
+        mDelegate.expand();
     }
 
     /**
@@ -197,11 +91,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void collapse() {
-        if (isAnimating) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), closePosition,
-                duration, interpolator).start();
+        mDelegate.collapse();
     }
 
     /**
@@ -209,13 +99,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void initLayout(final boolean isMaintain) {
-        closePosition = 0;
-        layoutSize = 0;
-        isArranged = isMaintain;
-        isCalculatedSize = false;
-        savedState = null;
-
-        super.requestLayout();
+        mDelegate.initLayout(isMaintain);
     }
 
     /**
@@ -223,11 +107,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void setDuration(final int duration) {
-        if (duration < 0) {
-            throw new IllegalArgumentException("Animators cannot have negative duration: " +
-                    duration);
-        }
-        this.duration = duration;
+        mDelegate.setDuration(duration);
     }
 
     /**
@@ -235,9 +115,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void setExpanded(boolean expanded) {
-        isExpanded = expanded;
-        isArranged = false;
-        requestLayout();
+        mDelegate.setExpanded(expanded);
     }
 
     /**
@@ -245,7 +123,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public boolean isExpanded() {
-        return isExpanded;
+        return mDelegate.isExpanded();
     }
 
     /**
@@ -253,7 +131,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      */
     @Override
     public void setInterpolator(@NonNull final TimeInterpolator interpolator) {
-        this.interpolator = interpolator;
+        mDelegate.setInterpolator(interpolator);
     }
 
     /**
@@ -261,7 +139,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * @see #move(int, long, TimeInterpolator)
      */
     public void move(int position) {
-        move(position, duration, interpolator);
+        mDelegate.move(position);
     }
 
     /**
@@ -272,14 +150,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * @param interpolator
      */
     public void move(int position, long duration, TimeInterpolator interpolator) {
-        if (isAnimating) {
-            return;
-        }
-        if (0 > position || layoutSize < position) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), position,
-                duration, interpolator).start();
+        mDelegate.move(position, duration, interpolator);
     }
 
     /**
@@ -287,7 +158,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * @see #moveChild(int, long, TimeInterpolator)
      */
     public void moveChild(int index) {
-        moveChild(index, duration, interpolator);
+        mDelegate.moveChild(index);
     }
 
     /**
@@ -298,11 +169,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * @param interpolator
      */
     public void moveChild(int index, long duration, TimeInterpolator interpolator) {
-        if (isAnimating) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), childPositionList.get(index),
-                duration, interpolator).start();
+        mDelegate.moveChild(index, duration, interpolator);
     }
 
     /**
@@ -311,7 +178,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * @param orientation Set 0 if orientation is horizontal, 1 if orientation is vertical
      */
     public void setOrientation(@Orientation final int orientation) {
-        this.orientation = orientation;
+        mDelegate.setOrientation(orientation);
     }
 
     /**
@@ -322,10 +189,7 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * @return position from top or left
      */
     public int getChildPosition(final int index) {
-        if (0 > index || childPositionList.size() <= index) {
-            throw new IllegalArgumentException("There aren't the view having this index.");
-        }
-        return childPositionList.get(index);
+        return mDelegate.getChildPosition(index);
     }
 
     /**
@@ -333,21 +197,19 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * Gets the height from top of layout if orientation is vertical.
      *
      * @return
-     * @see #closePosition
      */
     public int getClosePosition() {
-        return closePosition;
+        return mDelegate.getClosePosition();
     }
 
     /**
      * Sets the close position directly.
      *
      * @param position
-     * @see #closePosition
      * @see #setClosePositionIndex(int)
      */
     public void setClosePosition(final int position) {
-        this.closePosition = position;
+        mDelegate.setClosePosition(position);
     }
 
     /**
@@ -356,98 +218,16 @@ public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayo
      * @return
      */
     public int getCurrentPosition() {
-        return isVertical() ? getMeasuredHeight() : getMeasuredWidth();
+        return mDelegate.getCurrentPosition();
     }
 
     /**
      * Sets close position using index of child view.
      *
      * @param childIndex
-     * @see #closePosition
      * @see #setClosePosition(int)
      */
     public void setClosePositionIndex(final int childIndex) {
-        this.closePosition = getChildPosition(childIndex);
-    }
-
-    private boolean isVertical() {
-        return orientation == VERTICAL;
-    }
-
-    private void setLayoutSize(int size) {
-        if (isVertical()) {
-            getLayoutParams().height = size;
-        } else {
-            getLayoutParams().width = size;
-        }
-    }
-
-    /**
-     * Creates value animator.
-     * Expand the layout if {@param to} is bigger than {@param from}.
-     * Collapse the layout if {@param from} is bigger than {@param to}.
-     *
-     * @param from
-     * @param to
-     * @param duration
-     * @param interpolator
-     * @return
-     */
-    private ValueAnimator createExpandAnimator(
-            final int from, final int to, final long duration, final TimeInterpolator interpolator) {
-        final ValueAnimator valueAnimator = ValueAnimator.ofInt(from, to);
-        valueAnimator.setDuration(duration);
-        valueAnimator.setInterpolator(interpolator);
-        valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-            @Override
-            public void onAnimationUpdate(final ValueAnimator animator) {
-                if (isVertical()) {
-                    getLayoutParams().height = (int) animator.getAnimatedValue();
-                } else {
-                    getLayoutParams().width = (int) animator.getAnimatedValue();
-                }
-                requestLayout();
-            }
-        });
-        valueAnimator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationStart(Animator animator) {
-                isAnimating = true;
-                if (listener == null) {
-                    return;
-                }
-                listener.onAnimationStart();
-
-                if (layoutSize == to) {
-                    listener.onPreOpen();
-                    return;
-                }
-                if (closePosition == to) {
-                    listener.onPreClose();
-                }
-            }
-
-            @Override
-            public void onAnimationEnd(Animator animator) {
-                isAnimating = false;
-                final int currentSize = isVertical()
-                        ? getLayoutParams().height : getLayoutParams().width;
-                isExpanded = currentSize > closePosition;
-
-                if (listener == null) {
-                    return;
-                }
-                listener.onAnimationEnd();
-
-                if (currentSize == layoutSize) {
-                    listener.onOpened();
-                    return;
-                }
-                if (currentSize == closePosition) {
-                    listener.onClosed();
-                }
-            }
-        });
-        return valueAnimator;
+        mDelegate.setClosePositionIndex(childIndex);
     }
 }

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableFrameLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableFrameLayout.java
@@ -1,0 +1,453 @@
+package com.github.aakira.expandablelayout;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.TimeInterpolator;
+import android.animation.ValueAnimator;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Build;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.animation.LinearInterpolator;
+import android.widget.FrameLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayout {
+
+    private int duration;
+    private boolean isExpanded;
+    private TimeInterpolator interpolator = new LinearInterpolator();
+    private int orientation;
+    /**
+     * You cannot define {@link #isExpanded}, {@link #defaultChildIndex}
+     * and {@link #defaultChildPosition} at the same time.
+     * {@link #defaultChildPosition} has priority over {@link #isExpanded}
+     * and {@link #defaultChildIndex} if you set them at the same time.
+     */
+    private int defaultChildIndex;
+    private int defaultChildPosition;
+    /**
+     * The close position is width from left of layout if orientation is horizontal.
+     * The close position is height from top of layout if orientation is vertical.
+     */
+    private int closePosition = 0;
+
+    private ExpandableLayoutListener listener;
+    private ExpandableSavedState savedState;
+    private int layoutSize = 0;
+    private boolean isArranged = false;
+    private boolean isCalculatedSize = false;
+    private boolean isAnimating = false;
+    private List<Integer> childPositionList = new ArrayList<>();
+
+    public ExpandableFrameLayout(final Context context) {
+        this(context, null);
+    }
+
+    public ExpandableFrameLayout(final Context context, final AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ExpandableFrameLayout(final Context context, final AttributeSet attrs,
+                                    final int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs, defStyleAttr);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public ExpandableFrameLayout(final Context context, final AttributeSet attrs,
+                                    final int defStyleAttr, final int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context, attrs, defStyleAttr);
+    }
+
+    private void init(final Context context, final AttributeSet attrs, final int defStyleAttr) {
+        final TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.expandableLayout, defStyleAttr, 0);
+        duration = a.getInteger(R.styleable.expandableLayout_ael_duration, DEFAULT_DURATION);
+        isExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
+        orientation = a.getInteger(R.styleable.expandableLayout_ael_orientation, VERTICAL);
+        defaultChildIndex = a.getInteger(R.styleable.expandableLayout_ael_defaultChildIndex,
+                Integer.MAX_VALUE);
+        defaultChildPosition = a.getInteger(R.styleable.expandableLayout_ael_defaultPosition,
+                Integer.MIN_VALUE);
+        final int interpolatorType = a.getInteger(R.styleable.expandableLayout_ael_interpolator,
+                Utils.LINEAR_INTERPOLATOR);
+        interpolator = Utils.createInterpolator(interpolatorType);
+        a.recycle();
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+        if (!isCalculatedSize) {
+            // calculate this layout size
+            childPositionList.clear();
+            int childSize;
+            int childMargin;
+            int sumSize = 0;
+            View view;
+            LayoutParams params;
+            for (int i = 0; i < getChildCount(); i++) {
+                view = getChildAt(i);
+                params = (LayoutParams) view.getLayoutParams();
+
+                childSize = isVertical()
+                        ? view.getMeasuredHeight() : view.getMeasuredWidth();
+                childMargin = isVertical()
+                        ? params.topMargin + params.bottomMargin
+                        : params.leftMargin + params.rightMargin;
+                if (0 < i) {
+                    sumSize = childPositionList.get(i - 1);
+                }
+                childPositionList.add(sumSize + childSize + childMargin);
+            }
+            layoutSize = childPositionList.get(childPositionList.size() - 1);
+
+            if (0 < layoutSize) {
+                isCalculatedSize = true;
+            }
+        }
+
+        if (isArranged) {
+            return;
+        }
+
+        if (isExpanded) {
+            setLayoutSize(layoutSize);
+        } else {
+            setLayoutSize(closePosition);
+        }
+        final int childNumbers = childPositionList.size();
+        if (childNumbers > defaultChildIndex && childNumbers > 0) {
+            moveChild(defaultChildIndex, 0, null);
+        }
+        if (defaultChildPosition > 0 && layoutSize >= defaultChildPosition && layoutSize > 0) {
+            move(defaultChildPosition, 0, null);
+        }
+        isArranged = true;
+
+        if (savedState == null) {
+            return;
+        }
+        setLayoutSize(savedState.getSize());
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        final Parcelable parcelable = super.onSaveInstanceState();
+        final ExpandableSavedState ss = new ExpandableSavedState(parcelable);
+        ss.setSize(getCurrentPosition());
+        return ss;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(final Parcelable state) {
+        if (!(state instanceof ExpandableSavedState)) {
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        final ExpandableSavedState ss = (ExpandableSavedState) state;
+        super.onRestoreInstanceState(ss.getSuperState());
+        savedState = ss;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setListener(@NonNull ExpandableLayoutListener listener) {
+        this.listener = listener;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void toggle() {
+        if (closePosition < getCurrentPosition()) {
+            collapse();
+        } else {
+            expand();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void expand() {
+        if (isAnimating) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), layoutSize,
+                duration, interpolator).start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void collapse() {
+        if (isAnimating) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), closePosition,
+                duration, interpolator).start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initLayout(final boolean isMaintain) {
+        closePosition = 0;
+        layoutSize = 0;
+        isArranged = isMaintain;
+        isCalculatedSize = false;
+        savedState = null;
+
+        super.requestLayout();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDuration(final int duration) {
+        if (duration < 0) {
+            throw new IllegalArgumentException("Animators cannot have negative duration: " +
+                    duration);
+        }
+        this.duration = duration;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setExpanded(boolean expanded) {
+        isExpanded = expanded;
+        isArranged = false;
+        requestLayout();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isExpanded() {
+        return isExpanded;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setInterpolator(@NonNull final TimeInterpolator interpolator) {
+        this.interpolator = interpolator;
+    }
+
+    /**
+     * @param position
+     * @see #move(int, long, TimeInterpolator)
+     */
+    public void move(int position) {
+        move(position, duration, interpolator);
+    }
+
+    /**
+     * Moves to position
+     *
+     * @param position
+     * @param duration
+     * @param interpolator
+     */
+    public void move(int position, long duration, TimeInterpolator interpolator) {
+        if (isAnimating) {
+            return;
+        }
+        if (0 > position || layoutSize < position) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), position,
+                duration, interpolator).start();
+    }
+
+    /**
+     * @param index child view index
+     * @see #moveChild(int, long, TimeInterpolator)
+     */
+    public void moveChild(int index) {
+        moveChild(index, duration, interpolator);
+    }
+
+    /**
+     * Moves to bottom(VERTICAL) or right(HORIZONTAL) of child view
+     *
+     * @param index        index child view index
+     * @param duration
+     * @param interpolator
+     */
+    public void moveChild(int index, long duration, TimeInterpolator interpolator) {
+        if (isAnimating) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), childPositionList.get(index),
+                duration, interpolator).start();
+    }
+
+    /**
+     * Sets orientation of expanse animation.
+     *
+     * @param orientation Set 0 if orientation is horizontal, 1 if orientation is vertical
+     */
+    public void setOrientation(@Orientation final int orientation) {
+        this.orientation = orientation;
+    }
+
+    /**
+     * Gets the width from left of layout if orientation is horizontal.
+     * Gets the height from top of layout if orientation is vertical.
+     *
+     * @param index index of child view
+     * @return position from top or left
+     */
+    public int getChildPosition(final int index) {
+        if (0 > index || childPositionList.size() <= index) {
+            throw new IllegalArgumentException("There aren't the view having this index.");
+        }
+        return childPositionList.get(index);
+    }
+
+    /**
+     * Gets the width from left of layout if orientation is horizontal.
+     * Gets the height from top of layout if orientation is vertical.
+     *
+     * @return
+     * @see #closePosition
+     */
+    public int getClosePosition() {
+        return closePosition;
+    }
+
+    /**
+     * Sets the close position directly.
+     *
+     * @param position
+     * @see #closePosition
+     * @see #setClosePositionIndex(int)
+     */
+    public void setClosePosition(final int position) {
+        this.closePosition = position;
+    }
+
+    /**
+     * Gets the current position.
+     *
+     * @return
+     */
+    public int getCurrentPosition() {
+        return isVertical() ? getMeasuredHeight() : getMeasuredWidth();
+    }
+
+    /**
+     * Sets close position using index of child view.
+     *
+     * @param childIndex
+     * @see #closePosition
+     * @see #setClosePosition(int)
+     */
+    public void setClosePositionIndex(final int childIndex) {
+        this.closePosition = getChildPosition(childIndex);
+    }
+
+    private boolean isVertical() {
+        return orientation == VERTICAL;
+    }
+
+    private void setLayoutSize(int size) {
+        if (isVertical()) {
+            getLayoutParams().height = size;
+        } else {
+            getLayoutParams().width = size;
+        }
+    }
+
+    /**
+     * Creates value animator.
+     * Expand the layout if {@param to} is bigger than {@param from}.
+     * Collapse the layout if {@param from} is bigger than {@param to}.
+     *
+     * @param from
+     * @param to
+     * @param duration
+     * @param interpolator
+     * @return
+     */
+    private ValueAnimator createExpandAnimator(
+            final int from, final int to, final long duration, final TimeInterpolator interpolator) {
+        final ValueAnimator valueAnimator = ValueAnimator.ofInt(from, to);
+        valueAnimator.setDuration(duration);
+        valueAnimator.setInterpolator(interpolator);
+        valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+            @Override
+            public void onAnimationUpdate(final ValueAnimator animator) {
+                if (isVertical()) {
+                    getLayoutParams().height = (int) animator.getAnimatedValue();
+                } else {
+                    getLayoutParams().width = (int) animator.getAnimatedValue();
+                }
+                requestLayout();
+            }
+        });
+        valueAnimator.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationStart(Animator animator) {
+                isAnimating = true;
+                if (listener == null) {
+                    return;
+                }
+                listener.onAnimationStart();
+
+                if (layoutSize == to) {
+                    listener.onPreOpen();
+                    return;
+                }
+                if (closePosition == to) {
+                    listener.onPreClose();
+                }
+            }
+
+            @Override
+            public void onAnimationEnd(Animator animator) {
+                isAnimating = false;
+                final int currentSize = isVertical()
+                        ? getLayoutParams().height : getLayoutParams().width;
+                isExpanded = currentSize > closePosition;
+
+                if (listener == null) {
+                    return;
+                }
+                listener.onAnimationEnd();
+
+                if (currentSize == layoutSize) {
+                    listener.onOpened();
+                    return;
+                }
+                if (currentSize == closePosition) {
+                    listener.onClosed();
+                }
+            }
+        });
+        return valueAnimator;
+    }
+}

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayoutDelegate.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayoutDelegate.java
@@ -1,0 +1,369 @@
+package com.github.aakira.expandablelayout;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.TimeInterpolator;
+import android.animation.ValueAnimator;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.LinearInterpolator;
+import android.widget.RelativeLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Delegate which all layouts can share to have the same Expandable behaviour
+ */
+public class ExpandableLayoutDelegate {
+
+    private ViewGroup viewGroup;
+
+    private int duration;
+    private boolean isExpanded;
+    private TimeInterpolator interpolator = new LinearInterpolator();
+    private int orientation;
+    /**
+     * You cannot define {@link #isExpanded}, {@link #defaultChildIndex}
+     * and {@link #defaultChildPosition} at the same time.
+     * {@link #defaultChildPosition} has priority over {@link #isExpanded}
+     * and {@link #defaultChildIndex} if you set them at the same time.
+     */
+    private int defaultChildIndex;
+    private int defaultChildPosition;
+    /**
+     * The close position is width from left of layout if orientation is horizontal.
+     * The close position is height from top of layout if orientation is vertical.
+     */
+    private int closePosition = 0;
+
+    private ExpandableLayoutListener listener;
+    private ExpandableSavedState savedState;
+    private int layoutSize = 0;
+    private boolean isArranged = false;
+    private boolean isCalculatedSize = false;
+    private boolean isAnimating = false;
+    private List<Integer> childPositionList = new ArrayList<>();
+
+    public ExpandableLayoutDelegate(ViewGroup viewGroup) {
+        this.viewGroup = viewGroup;
+    }
+
+    public void init(final Context context, final AttributeSet attrs, final int defStyleAttr) {
+        final TypedArray a = context.obtainStyledAttributes(
+                attrs, R.styleable.expandableLayout, defStyleAttr, 0);
+        duration = a.getInteger(R.styleable.expandableLayout_ael_duration, ExpandableLayout.DEFAULT_DURATION);
+        isExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, ExpandableLayout.DEFAULT_EXPANDED);
+        orientation = a.getInteger(R.styleable.expandableLayout_ael_orientation, ExpandableLayout.VERTICAL);
+        defaultChildIndex = a.getInteger(R.styleable.expandableLayout_ael_defaultChildIndex,
+                Integer.MAX_VALUE);
+        defaultChildPosition = a.getInteger(R.styleable.expandableLayout_ael_defaultPosition,
+                Integer.MIN_VALUE);
+        final int interpolatorType = a.getInteger(R.styleable.expandableLayout_ael_interpolator,
+                Utils.LINEAR_INTERPOLATOR);
+        interpolator = Utils.createInterpolator(interpolatorType);
+        a.recycle();
+    }
+
+    public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if (!isCalculatedSize) {
+            // calculate this layout size
+            childPositionList.clear();
+            int childSize;
+            int childMargin;
+            int sumSize = 0;
+            View view;
+            RelativeLayout.LayoutParams params;
+            for (int i = 0; i < viewGroup.getChildCount(); i++) {
+                view = viewGroup.getChildAt(i);
+                params = (RelativeLayout.LayoutParams) view.getLayoutParams();
+
+                childSize = isVertical()
+                        ? view.getMeasuredHeight() : view.getMeasuredWidth();
+                childMargin = isVertical()
+                        ? params.topMargin + params.bottomMargin
+                        : params.leftMargin + params.rightMargin;
+                if (0 < i) {
+                    sumSize = childPositionList.get(i - 1);
+                }
+                childPositionList.add(sumSize + childSize + childMargin);
+            }
+            layoutSize = childPositionList.get(childPositionList.size() - 1);
+
+            if (0 < layoutSize) {
+                isCalculatedSize = true;
+            }
+        }
+
+        if (isArranged) {
+            return;
+        }
+
+        if (isExpanded) {
+            setLayoutSize(layoutSize);
+        } else {
+            setLayoutSize(closePosition);
+        }
+        final int childNumbers = childPositionList.size();
+        if (childNumbers > defaultChildIndex && childNumbers > 0) {
+            moveChild(defaultChildIndex, 0, null);
+        }
+        if (defaultChildPosition > 0 && layoutSize >= defaultChildPosition && layoutSize > 0) {
+            move(defaultChildPosition, 0, null);
+        }
+        isArranged = true;
+
+        if (savedState == null) {
+            return;
+        }
+        setLayoutSize(savedState.getSize());
+    }
+
+    public Parcelable onSaveInstanceState(Parcelable resultOfSuper) {
+        final ExpandableSavedState ss = new ExpandableSavedState(resultOfSuper);
+        ss.setSize(getCurrentPosition());
+        return ss;
+    }
+
+    public void onRestoreInstanceState(final ExpandableSavedState resultOfOnRestoreInstanceState) {
+        savedState = resultOfOnRestoreInstanceState;
+    }
+
+    public void setListener(@NonNull ExpandableLayoutListener listener) {
+        this.listener = listener;
+    }
+
+    public void toggle() {
+        if (closePosition < getCurrentPosition()) {
+            collapse();
+        } else {
+            expand();
+        }
+    }
+
+    public void expand() {
+        if (isAnimating) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), layoutSize,
+                duration, interpolator).start();
+    }
+
+    public void collapse() {
+        if (isAnimating) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), closePosition,
+                duration, interpolator).start();
+    }
+
+    public void initLayout(final boolean isMaintain) {
+        closePosition = 0;
+        layoutSize = 0;
+        isArranged = isMaintain;
+        isCalculatedSize = false;
+        savedState = null;
+
+        viewGroup.requestLayout();
+    }
+
+    public void setDuration(final int duration) {
+        if (duration < 0) {
+            throw new IllegalArgumentException("Animators cannot have negative duration: " +
+                    duration);
+        }
+        this.duration = duration;
+    }
+
+    public void setExpanded(boolean expanded) {
+        isExpanded = expanded;
+        isArranged = false;
+        viewGroup.requestLayout();
+    }
+
+    public boolean isExpanded() {
+        return isExpanded;
+    }
+
+    public void setInterpolator(@NonNull final TimeInterpolator interpolator) {
+        this.interpolator = interpolator;
+    }
+
+    public void move(int position) {
+        move(position, duration, interpolator);
+    }
+
+    public void move(int position, long duration, TimeInterpolator interpolator) {
+        if (isAnimating) {
+            return;
+        }
+        if (0 > position || layoutSize < position) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), position,
+                duration, interpolator).start();
+    }
+
+    public void moveChild(int index) {
+        moveChild(index, duration, interpolator);
+    }
+
+    public void moveChild(int index, long duration, TimeInterpolator interpolator) {
+        if (isAnimating) {
+            return;
+        }
+        createExpandAnimator(getCurrentPosition(), childPositionList.get(index),
+                duration, interpolator).start();
+    }
+
+    /**
+     * Sets orientation of expanse animation.
+     *
+     * @param orientation Set 0 if orientation is horizontal, 1 if orientation is vertical
+     */
+    public void setOrientation(@ExpandableLayout.Orientation final int orientation) {
+        this.orientation = orientation;
+    }
+
+    /**
+     * Gets the width from left of layout if orientation is horizontal.
+     * Gets the height from top of layout if orientation is vertical.
+     *
+     * @param index index of child view
+     * @return position from top or left
+     */
+    public int getChildPosition(final int index) {
+        if (0 > index || childPositionList.size() <= index) {
+            throw new IllegalArgumentException("There aren't the view having this index.");
+        }
+        return childPositionList.get(index);
+    }
+
+    /**
+     * Gets the width from left of layout if orientation is horizontal.
+     * Gets the height from top of layout if orientation is vertical.
+     *
+     * @return
+     * @see #closePosition
+     */
+    public int getClosePosition() {
+        return closePosition;
+    }
+
+    /**
+     * Sets the close position directly.
+     *
+     * @param position
+     * @see #closePosition
+     * @see #setClosePositionIndex(int)
+     */
+    public void setClosePosition(final int position) {
+        this.closePosition = position;
+    }
+
+    /**
+     * Gets the current position.
+     *
+     * @return
+     */
+    public int getCurrentPosition() {
+        return isVertical() ? viewGroup.getMeasuredHeight() : viewGroup.getMeasuredWidth();
+    }
+
+    /**
+     * Sets close position using index of child view.
+     *
+     * @param childIndex
+     * @see #closePosition
+     * @see #setClosePosition(int)
+     */
+    public void setClosePositionIndex(final int childIndex) {
+        this.closePosition = getChildPosition(childIndex);
+    }
+
+    private boolean isVertical() {
+        return orientation == ExpandableLayout.VERTICAL;
+    }
+
+    private void setLayoutSize(int size) {
+        if (isVertical()) {
+            viewGroup.getLayoutParams().height = size;
+        } else {
+            viewGroup.getLayoutParams().width = size;
+        }
+    }
+
+    /**
+     * Creates value animator.
+     * Expand the layout if {@param to} is bigger than {@param from}.
+     * Collapse the layout if {@param from} is bigger than {@param to}.
+     *
+     * @param from
+     * @param to
+     * @param duration
+     * @param interpolator
+     * @return
+     */
+    private ValueAnimator createExpandAnimator(
+            final int from, final int to, final long duration, final TimeInterpolator interpolator) {
+        final ValueAnimator valueAnimator = ValueAnimator.ofInt(from, to);
+        valueAnimator.setDuration(duration);
+        valueAnimator.setInterpolator(interpolator);
+        valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+            @Override
+            public void onAnimationUpdate(final ValueAnimator animator) {
+                if (isVertical()) {
+                    viewGroup.getLayoutParams().height = (int) animator.getAnimatedValue();
+                } else {
+                    viewGroup.getLayoutParams().width = (int) animator.getAnimatedValue();
+                }
+                viewGroup.requestLayout();
+            }
+        });
+        valueAnimator.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationStart(Animator animator) {
+                isAnimating = true;
+                if (listener == null) {
+                    return;
+                }
+                listener.onAnimationStart();
+
+                if (layoutSize == to) {
+                    listener.onPreOpen();
+                    return;
+                }
+                if (closePosition == to) {
+                    listener.onPreClose();
+                }
+            }
+
+            @Override
+            public void onAnimationEnd(Animator animator) {
+                isAnimating = false;
+                final int currentSize = isVertical()
+                        ? viewGroup.getLayoutParams().height : viewGroup.getLayoutParams().width;
+                isExpanded = currentSize > closePosition;
+
+                if (listener == null) {
+                    return;
+                }
+                listener.onAnimationEnd();
+
+                if (currentSize == layoutSize) {
+                    listener.onOpened();
+                    return;
+                }
+                if (currentSize == closePosition) {
+                    listener.onClosed();
+                }
+            }
+        });
+        return valueAnimator;
+    }
+}

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayoutDelegate.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayoutDelegate.java
@@ -12,7 +12,6 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.LinearInterpolator;
-import android.widget.RelativeLayout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,10 +77,10 @@ public class ExpandableLayoutDelegate {
             int childMargin;
             int sumSize = 0;
             View view;
-            RelativeLayout.LayoutParams params;
+            ViewGroup.MarginLayoutParams params;
             for (int i = 0; i < viewGroup.getChildCount(); i++) {
                 view = viewGroup.getChildAt(i);
-                params = (RelativeLayout.LayoutParams) view.getLayoutParams();
+                params = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
 
                 childSize = isVertical()
                         ? view.getMeasuredHeight() : view.getMeasuredWidth();

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayoutDelegate.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayoutDelegate.java
@@ -193,10 +193,21 @@ public class ExpandableLayoutDelegate {
         this.interpolator = interpolator;
     }
 
+    /**
+     * @param position
+     * @see #move(int, long, TimeInterpolator)
+     */
     public void move(int position) {
         move(position, duration, interpolator);
     }
 
+    /**
+     * Moves to position
+     *
+     * @param position
+     * @param duration
+     * @param interpolator
+     */
     public void move(int position, long duration, TimeInterpolator interpolator) {
         if (isAnimating) {
             return;
@@ -208,10 +219,21 @@ public class ExpandableLayoutDelegate {
                 duration, interpolator).start();
     }
 
+    /**
+     * @param index child view index
+     * @see #moveChild(int, long, TimeInterpolator)
+     */
     public void moveChild(int index) {
         moveChild(index, duration, interpolator);
     }
 
+    /**
+     * Moves to bottom(VERTICAL) or right(HORIZONTAL) of child view
+     *
+     * @param index        index child view index
+     * @param duration
+     * @param interpolator
+     */
     public void moveChild(int index, long duration, TimeInterpolator interpolator) {
         if (isAnimating) {
             return;
@@ -225,7 +247,7 @@ public class ExpandableLayoutDelegate {
      *
      * @param orientation Set 0 if orientation is horizontal, 1 if orientation is vertical
      */
-    public void setOrientation(@ExpandableLayout.Orientation final int orientation) {
+    public void setExpanseOrientation(@ExpandableLayout.Orientation final int orientation) {
         this.orientation = orientation;
     }
 

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
@@ -7,29 +7,29 @@ import android.os.Build;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
-import android.widget.FrameLayout;
+import android.widget.LinearLayout;
 
-public class ExpandableFrameLayout extends FrameLayout implements ExpandableLayout {
+public class ExpandableLinearLayout extends LinearLayout implements ExpandableLayout {
 
     private ExpandableLayoutDelegate mDelegate;
 
-    public ExpandableFrameLayout(final Context context) {
+    public ExpandableLinearLayout(final Context context) {
         this(context, null);
     }
 
-    public ExpandableFrameLayout(final Context context, final AttributeSet attrs) {
+    public ExpandableLinearLayout(final Context context, final AttributeSet attrs) {
         this(context, attrs, 0);
     }
 
-    public ExpandableFrameLayout(final Context context, final AttributeSet attrs,
-                                    final int defStyleAttr) {
+    public ExpandableLinearLayout(final Context context, final AttributeSet attrs,
+                                 final int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init(context, attrs, defStyleAttr);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public ExpandableFrameLayout(final Context context, final AttributeSet attrs,
-                                    final int defStyleAttr, final int defStyleRes) {
+    public ExpandableLinearLayout(final Context context, final AttributeSet attrs,
+                                 final int defStyleAttr, final int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
         init(context, attrs, defStyleAttr);
     }

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
@@ -1,50 +1,17 @@
 package com.github.aakira.expandablelayout;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.animation.TimeInterpolator;
-import android.animation.ValueAnimator;
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.os.Build;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
-import android.view.View;
-import android.view.animation.LinearInterpolator;
 import android.widget.RelativeLayout;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class ExpandableRelativeLayout extends RelativeLayout implements ExpandableLayout {
 
-    private int duration;
-    private boolean isExpanded;
-    private TimeInterpolator interpolator = new LinearInterpolator();
-    private int orientation;
-    /**
-     * You cannot define {@link #isExpanded}, {@link #defaultChildIndex}
-     * and {@link #defaultChildPosition} at the same time.
-     * {@link #defaultChildPosition} has priority over {@link #isExpanded}
-     * and {@link #defaultChildIndex} if you set them at the same time.
-     */
-    private int defaultChildIndex;
-    private int defaultChildPosition;
-    /**
-     * The close position is width from left of layout if orientation is horizontal.
-     * The close position is height from top of layout if orientation is vertical.
-     */
-    private int closePosition = 0;
-
-    private ExpandableLayoutListener listener;
-    private ExpandableSavedState savedState;
-    private int layoutSize = 0;
-    private boolean isArranged = false;
-    private boolean isCalculatedSize = false;
-    private boolean isAnimating = false;
-    private List<Integer> childPositionList = new ArrayList<>();
+    private ExpandableLayoutDelegate mDelegate;
 
     public ExpandableRelativeLayout(final Context context) {
         this(context, null);
@@ -68,84 +35,19 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
     }
 
     private void init(final Context context, final AttributeSet attrs, final int defStyleAttr) {
-        final TypedArray a = context.obtainStyledAttributes(
-                attrs, R.styleable.expandableLayout, defStyleAttr, 0);
-        duration = a.getInteger(R.styleable.expandableLayout_ael_duration, DEFAULT_DURATION);
-        isExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
-        orientation = a.getInteger(R.styleable.expandableLayout_ael_orientation, VERTICAL);
-        defaultChildIndex = a.getInteger(R.styleable.expandableLayout_ael_defaultChildIndex,
-                Integer.MAX_VALUE);
-        defaultChildPosition = a.getInteger(R.styleable.expandableLayout_ael_defaultPosition,
-                Integer.MIN_VALUE);
-        final int interpolatorType = a.getInteger(R.styleable.expandableLayout_ael_interpolator,
-                Utils.LINEAR_INTERPOLATOR);
-        interpolator = Utils.createInterpolator(interpolatorType);
-        a.recycle();
+        mDelegate = new ExpandableLayoutDelegate(this);
+        mDelegate.init(context, attrs, defStyleAttr);
     }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-
-        if (!isCalculatedSize) {
-            // calculate this layout size
-            childPositionList.clear();
-            int childSize;
-            int childMargin;
-            int sumSize = 0;
-            View view;
-            LayoutParams params;
-            for (int i = 0; i < getChildCount(); i++) {
-                view = getChildAt(i);
-                params = (LayoutParams) view.getLayoutParams();
-
-                childSize = isVertical()
-                        ? view.getMeasuredHeight() : view.getMeasuredWidth();
-                childMargin = isVertical()
-                        ? params.topMargin + params.bottomMargin
-                        : params.leftMargin + params.rightMargin;
-                if (0 < i) {
-                    sumSize = childPositionList.get(i - 1);
-                }
-                childPositionList.add(sumSize + childSize + childMargin);
-            }
-            layoutSize = childPositionList.get(childPositionList.size() - 1);
-
-            if (0 < layoutSize) {
-                isCalculatedSize = true;
-            }
-        }
-
-        if (isArranged) {
-            return;
-        }
-
-        if (isExpanded) {
-            setLayoutSize(layoutSize);
-        } else {
-            setLayoutSize(closePosition);
-        }
-        final int childNumbers = childPositionList.size();
-        if (childNumbers > defaultChildIndex && childNumbers > 0) {
-            moveChild(defaultChildIndex, 0, null);
-        }
-        if (defaultChildPosition > 0 && layoutSize >= defaultChildPosition && layoutSize > 0) {
-            move(defaultChildPosition, 0, null);
-        }
-        isArranged = true;
-
-        if (savedState == null) {
-            return;
-        }
-        setLayoutSize(savedState.getSize());
+        mDelegate.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 
     @Override
     protected Parcelable onSaveInstanceState() {
-        final Parcelable parcelable = super.onSaveInstanceState();
-        final ExpandableSavedState ss = new ExpandableSavedState(parcelable);
-        ss.setSize(getCurrentPosition());
-        return ss;
+        return mDelegate.onSaveInstanceState(super.onSaveInstanceState());
     }
 
     @Override
@@ -157,7 +59,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
 
         final ExpandableSavedState ss = (ExpandableSavedState) state;
         super.onRestoreInstanceState(ss.getSuperState());
-        savedState = ss;
+        mDelegate.onRestoreInstanceState(ss);
     }
 
     /**
@@ -165,7 +67,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void setListener(@NonNull ExpandableLayoutListener listener) {
-        this.listener = listener;
+        mDelegate.setListener(listener);
     }
 
     /**
@@ -173,11 +75,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void toggle() {
-        if (closePosition < getCurrentPosition()) {
-            collapse();
-        } else {
-            expand();
-        }
+        mDelegate.toggle();
     }
 
     /**
@@ -185,11 +83,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void expand() {
-        if (isAnimating) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), layoutSize,
-                duration, interpolator).start();
+        mDelegate.expand();
     }
 
     /**
@@ -197,11 +91,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void collapse() {
-        if (isAnimating) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), closePosition,
-                duration, interpolator).start();
+        mDelegate.collapse();
     }
 
     /**
@@ -209,13 +99,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void initLayout(final boolean isMaintain) {
-        closePosition = 0;
-        layoutSize = 0;
-        isArranged = isMaintain;
-        isCalculatedSize = false;
-        savedState = null;
-
-        super.requestLayout();
+        mDelegate.initLayout(isMaintain);
     }
 
     /**
@@ -223,11 +107,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void setDuration(final int duration) {
-        if (duration < 0) {
-            throw new IllegalArgumentException("Animators cannot have negative duration: " +
-                    duration);
-        }
-        this.duration = duration;
+        mDelegate.setDuration(duration);
     }
 
     /**
@@ -235,9 +115,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void setExpanded(boolean expanded) {
-        isExpanded = expanded;
-        isArranged = false;
-        requestLayout();
+        mDelegate.setExpanded(expanded);
     }
 
     /**
@@ -245,7 +123,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public boolean isExpanded() {
-        return isExpanded;
+        return mDelegate.isExpanded();
     }
 
     /**
@@ -253,7 +131,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void setInterpolator(@NonNull final TimeInterpolator interpolator) {
-        this.interpolator = interpolator;
+        mDelegate.setInterpolator(interpolator);
     }
 
     /**
@@ -261,7 +139,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * @see #move(int, long, TimeInterpolator)
      */
     public void move(int position) {
-        move(position, duration, interpolator);
+        mDelegate.move(position);
     }
 
     /**
@@ -272,14 +150,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * @param interpolator
      */
     public void move(int position, long duration, TimeInterpolator interpolator) {
-        if (isAnimating) {
-            return;
-        }
-        if (0 > position || layoutSize < position) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), position,
-                duration, interpolator).start();
+        mDelegate.move(position, duration, interpolator);
     }
 
     /**
@@ -287,7 +158,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * @see #moveChild(int, long, TimeInterpolator)
      */
     public void moveChild(int index) {
-        moveChild(index, duration, interpolator);
+        mDelegate.moveChild(index);
     }
 
     /**
@@ -298,11 +169,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * @param interpolator
      */
     public void moveChild(int index, long duration, TimeInterpolator interpolator) {
-        if (isAnimating) {
-            return;
-        }
-        createExpandAnimator(getCurrentPosition(), childPositionList.get(index),
-                duration, interpolator).start();
+        mDelegate.moveChild(index, duration, interpolator);
     }
 
     /**
@@ -311,7 +178,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * @param orientation Set 0 if orientation is horizontal, 1 if orientation is vertical
      */
     public void setOrientation(@Orientation final int orientation) {
-        this.orientation = orientation;
+        mDelegate.setOrientation(orientation);
     }
 
     /**
@@ -322,10 +189,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * @return position from top or left
      */
     public int getChildPosition(final int index) {
-        if (0 > index || childPositionList.size() <= index) {
-            throw new IllegalArgumentException("There aren't the view having this index.");
-        }
-        return childPositionList.get(index);
+        return mDelegate.getChildPosition(index);
     }
 
     /**
@@ -333,21 +197,19 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * Gets the height from top of layout if orientation is vertical.
      *
      * @return
-     * @see #closePosition
      */
     public int getClosePosition() {
-        return closePosition;
+        return mDelegate.getClosePosition();
     }
 
     /**
      * Sets the close position directly.
      *
      * @param position
-     * @see #closePosition
      * @see #setClosePositionIndex(int)
      */
     public void setClosePosition(final int position) {
-        this.closePosition = position;
+        mDelegate.setClosePosition(position);
     }
 
     /**
@@ -356,98 +218,16 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * @return
      */
     public int getCurrentPosition() {
-        return isVertical() ? getMeasuredHeight() : getMeasuredWidth();
+        return mDelegate.getCurrentPosition();
     }
 
     /**
      * Sets close position using index of child view.
      *
      * @param childIndex
-     * @see #closePosition
      * @see #setClosePosition(int)
      */
     public void setClosePositionIndex(final int childIndex) {
-        this.closePosition = getChildPosition(childIndex);
-    }
-
-    private boolean isVertical() {
-        return orientation == VERTICAL;
-    }
-
-    private void setLayoutSize(int size) {
-        if (isVertical()) {
-            getLayoutParams().height = size;
-        } else {
-            getLayoutParams().width = size;
-        }
-    }
-
-    /**
-     * Creates value animator.
-     * Expand the layout if {@param to} is bigger than {@param from}.
-     * Collapse the layout if {@param from} is bigger than {@param to}.
-     *
-     * @param from
-     * @param to
-     * @param duration
-     * @param interpolator
-     * @return
-     */
-    private ValueAnimator createExpandAnimator(
-            final int from, final int to, final long duration, final TimeInterpolator interpolator) {
-        final ValueAnimator valueAnimator = ValueAnimator.ofInt(from, to);
-        valueAnimator.setDuration(duration);
-        valueAnimator.setInterpolator(interpolator);
-        valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-            @Override
-            public void onAnimationUpdate(final ValueAnimator animator) {
-                if (isVertical()) {
-                    getLayoutParams().height = (int) animator.getAnimatedValue();
-                } else {
-                    getLayoutParams().width = (int) animator.getAnimatedValue();
-                }
-                requestLayout();
-            }
-        });
-        valueAnimator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationStart(Animator animator) {
-                isAnimating = true;
-                if (listener == null) {
-                    return;
-                }
-                listener.onAnimationStart();
-
-                if (layoutSize == to) {
-                    listener.onPreOpen();
-                    return;
-                }
-                if (closePosition == to) {
-                    listener.onPreClose();
-                }
-            }
-
-            @Override
-            public void onAnimationEnd(Animator animator) {
-                isAnimating = false;
-                final int currentSize = isVertical()
-                        ? getLayoutParams().height : getLayoutParams().width;
-                isExpanded = currentSize > closePosition;
-
-                if (listener == null) {
-                    return;
-                }
-                listener.onAnimationEnd();
-
-                if (currentSize == layoutSize) {
-                    listener.onOpened();
-                    return;
-                }
-                if (currentSize == closePosition) {
-                    listener.onClosed();
-                }
-            }
-        });
-        return valueAnimator;
+        mDelegate.setClosePositionIndex(childIndex);
     }
 }

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
@@ -173,12 +173,19 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
     }
 
     /**
+     * @deprecated Use {@link #setExpanseOrientation(int)} instead
+     */
+    public void setOrientation(@Orientation final int orientation) {
+        setExpanseOrientation(orientation);
+    }
+
+    /**
      * Sets orientation of expanse animation.
      *
      * @param orientation Set 0 if orientation is horizontal, 1 if orientation is vertical
      */
-    public void setOrientation(@Orientation final int orientation) {
-        mDelegate.setOrientation(orientation);
+    public void setExpanseOrientation(@Orientation final int orientation) {
+        mDelegate.setExpanseOrientation(orientation);
     }
 
     /**

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
             android:name=".expandablelayout.ExpandableLayoutActivity"
             android:label="@string/app_name" />
         <activity
+            android:name=".expandablelayout.ExpandableLinearLayoutActivity"
+            android:label="@string/app_name"/>
+        <activity
             android:name=".expandableweight.ExpandableWeightActivity"
             android:label="@string/app_name" />
         <activity

--- a/sample/src/main/java/jp/android/aakira/sample/expandablelayout/examplesearch/ExampleSearchActivity.java
+++ b/sample/src/main/java/jp/android/aakira/sample/expandablelayout/examplesearch/ExampleSearchActivity.java
@@ -9,11 +9,12 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
 
+import com.github.aakira.expandablelayout.ExpandableFrameLayout;
+
 import java.util.ArrayList;
 
-import com.github.aakira.expandablelayout.ExpandableRelativeLayout;
-import jp.android.aakira.sample.expandablelayout.util.DividerItemDecoration;
 import jp.android.aakira.sample.expandablelayout.R;
+import jp.android.aakira.sample.expandablelayout.util.DividerItemDecoration;
 
 public class ExampleSearchActivity extends AppCompatActivity implements View.OnClickListener {
 
@@ -22,7 +23,7 @@ public class ExampleSearchActivity extends AppCompatActivity implements View.OnC
     }
 
     private Button mExpandButton;
-    private ExpandableRelativeLayout mExpandLayout;
+    private ExpandableFrameLayout mExpandLayout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -32,7 +33,7 @@ public class ExampleSearchActivity extends AppCompatActivity implements View.OnC
         getSupportActionBar().setTitle(ExampleSearchActivity.class.getSimpleName());
 
         mExpandButton = (Button) findViewById(R.id.expandButton);
-        mExpandLayout = (ExpandableRelativeLayout) findViewById(R.id.expandableLayout);
+        mExpandLayout = (ExpandableFrameLayout) findViewById(R.id.expandableLayout);
         mExpandButton.setOnClickListener(this);
 
         final RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recyclerView);

--- a/sample/src/main/java/jp/android/aakira/sample/expandablelayout/expandablelayout/ExpandableLinearLayoutActivity.java
+++ b/sample/src/main/java/jp/android/aakira/sample/expandablelayout/expandablelayout/ExpandableLinearLayoutActivity.java
@@ -1,0 +1,67 @@
+package jp.android.aakira.sample.expandablelayout.expandablelayout;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
+
+import com.github.aakira.expandablelayout.ExpandableLinearLayout;
+
+import jp.android.aakira.sample.expandablelayout.R;
+
+public class ExpandableLinearLayoutActivity extends AppCompatActivity implements View.OnClickListener {
+
+    public static void startActivity(Context context) {
+        context.startActivity(new Intent(context, ExpandableLinearLayoutActivity.class));
+    }
+
+    private Button mExpandButton;
+    private Button mMoveChildButton;
+    private Button mMoveChildButton2;
+    private Button mMoveTopButton;
+    private Button mSetCloseHeihgtButton;
+    private ExpandableLinearLayout mExpandLayout;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_expandable_linear_layout);
+
+        getSupportActionBar().setTitle(ExpandableLinearLayoutActivity.class.getSimpleName());
+
+        mExpandButton = (Button) findViewById(R.id.expandButton);
+        mMoveChildButton = (Button) findViewById(R.id.moveChildButton);
+        mMoveChildButton2 = (Button) findViewById(R.id.moveChildButton2);
+        mMoveTopButton = (Button) findViewById(R.id.moveTopButton);
+        mSetCloseHeihgtButton = (Button) findViewById(R.id.setCloseHeightButton);
+        mExpandLayout = (ExpandableLinearLayout) findViewById(R.id.expandableLayout);
+        mExpandButton.setOnClickListener(this);
+        mMoveChildButton.setOnClickListener(this);
+        mMoveChildButton2.setOnClickListener(this);
+        mMoveTopButton.setOnClickListener(this);
+        mSetCloseHeihgtButton.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(final View v) {
+        switch (v.getId()) {
+            case R.id.expandButton:
+                mExpandLayout.toggle();
+                break;
+            case R.id.moveChildButton:
+                mExpandLayout.moveChild(0);
+                break;
+            case R.id.moveChildButton2:
+                mExpandLayout.moveChild(1);
+                break;
+            case R.id.moveTopButton:
+                mExpandLayout.move(0);
+                break;
+            case R.id.setCloseHeightButton:
+                mExpandLayout.setClosePosition(mExpandLayout.getCurrentPosition());
+                break;
+        }
+    }
+}

--- a/sample/src/main/java/jp/android/aakira/sample/expandablelayout/main/MainActivity.java
+++ b/sample/src/main/java/jp/android/aakira/sample/expandablelayout/main/MainActivity.java
@@ -25,9 +25,10 @@ public class MainActivity extends AppCompatActivity {
 
         Map<Integer, String> data = new HashMap<>();
         data.put(0, "Normal\n[ExpandableRelativeLayout]");
-        data.put(1, "Normal\n[ExpandableWeightLayout]");
-        data.put(2, "Example(RecyclerView)\n[ExpandableRelativeLayout]");
-        data.put(3, "Example(Search screen)\n[ExpandableRelativeLayout]");
+        data.put(1, "Normal\n[ExpandableLinearLayout]");
+        data.put(2, "Normal\n[ExpandableWeightLayout]");
+        data.put(3, "Example(RecyclerView)\n[ExpandableRelativeLayout]");
+        data.put(4, "Example(Search screen)\n[ExpandableFrameLayout]");
 
         recyclerView.setAdapter(new MainRecyclerAdapter(this, data));
     }

--- a/sample/src/main/java/jp/android/aakira/sample/expandablelayout/main/MainRecyclerAdapter.java
+++ b/sample/src/main/java/jp/android/aakira/sample/expandablelayout/main/MainRecyclerAdapter.java
@@ -9,11 +9,12 @@ import android.widget.TextView;
 
 import java.util.Map;
 
-import jp.android.aakira.sample.expandablelayout.expandablelayout.ExpandableLayoutActivity;
-import jp.android.aakira.sample.expandablelayout.expandableweight.ExpandableWeightActivity;
 import jp.android.aakira.sample.expandablelayout.R;
 import jp.android.aakira.sample.expandablelayout.examplerecyclerview.RecyclerViewActivity;
 import jp.android.aakira.sample.expandablelayout.examplesearch.ExampleSearchActivity;
+import jp.android.aakira.sample.expandablelayout.expandablelayout.ExpandableLayoutActivity;
+import jp.android.aakira.sample.expandablelayout.expandablelayout.ExpandableLinearLayoutActivity;
+import jp.android.aakira.sample.expandablelayout.expandableweight.ExpandableWeightActivity;
 
 public class MainRecyclerAdapter extends RecyclerView.Adapter<MainRecyclerAdapter.ViewHolder> {
 
@@ -41,12 +42,15 @@ public class MainRecyclerAdapter extends RecyclerView.Adapter<MainRecyclerAdapte
                         ExpandableLayoutActivity.startActivity(context);
                         break;
                     case 1:
-                        ExpandableWeightActivity.startActivity(context);
+                        ExpandableLinearLayoutActivity.startActivity(context);
                         break;
                     case 2:
-                        RecyclerViewActivity.startActivity(context);
+                        ExpandableWeightActivity.startActivity(context);
                         break;
                     case 3:
+                        RecyclerViewActivity.startActivity(context);
+                        break;
+                    case 4:
                         ExampleSearchActivity.startActivity(context);
                         break;
                 }

--- a/sample/src/main/res/layout/activity_example_search.xml
+++ b/sample/src/main/res/layout/activity_example_search.xml
@@ -20,7 +20,7 @@
         android:layout_alignParentTop="true"
         android:layout_toLeftOf="@id/expandButton" />
 
-    <com.github.aakira.expandablelayout.ExpandableRelativeLayout
+    <com.github.aakira.expandablelayout.ExpandableFrameLayout
         android:id="@+id/expandableLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -35,5 +35,5 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical" />
-    </com.github.aakira.expandablelayout.ExpandableRelativeLayout>
+    </com.github.aakira.expandablelayout.ExpandableFrameLayout>
 </RelativeLayout>

--- a/sample/src/main/res/layout/activity_expandable_linear_layout.xml
+++ b/sample/src/main/res/layout/activity_expandable_linear_layout.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/column1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/gray_light"
+        android:orientation="horizontal"
+        android:padding="1dp">
+
+        <Button
+            android:id="@+id/expandButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="1dp"
+            android:layout_weight="1"
+            android:background="@drawable/white"
+            android:text="Toggle" />
+
+        <Button
+            android:id="@+id/moveChildButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="1dp"
+            android:layout_weight="1"
+            android:background="@drawable/white"
+            android:text="Move child1" />
+
+        <Button
+            android:id="@+id/moveChildButton2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/white"
+            android:text="Move child2" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/column2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/column1"
+        android:background="@color/gray_light"
+        android:orientation="horizontal"
+        android:paddingBottom="1dp"
+        android:paddingLeft="1dp"
+        android:paddingRight="1dp">
+
+        <Button
+            android:id="@+id/moveTopButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="1dp"
+            android:layout_weight="1"
+            android:background="@drawable/white"
+            android:text="Top" />
+
+        <Button
+            android:id="@+id/setCloseHeightButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            android:background="@drawable/white"
+            android:text="Set close height" />
+    </LinearLayout>
+
+    <com.github.aakira.expandablelayout.ExpandableLinearLayout
+        android:id="@+id/expandableLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:layout_below="@id/column2"
+        android:background="@color/material_light_blue_500"
+        app:ael_duration="500"
+        app:ael_interpolator="bounce"
+        app:ael_orientation="vertical">
+
+        <TextView
+            android:id="@+id/one"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/material_cyan_500"
+            android:padding="@dimen/margin_small"
+            android:text="
+    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
+    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
+    "
+            android:textColor="@color/white" />
+
+        <TextView
+            android:id="@+id/two"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/one"
+            android:background="@color/material_blue_500"
+            android:padding="@dimen/margin_small"
+            android:text="
+    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
+    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
+    "
+            android:textColor="@color/white" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/two"
+            android:background="@color/material_indigo_500"
+            android:padding="@dimen/margin_small"
+            android:text="
+    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
+    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
+    "
+            android:textColor="@color/white" />
+    </com.github.aakira.expandablelayout.ExpandableLinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
Hey there @AAkira, really nice library.

This PR basically abstracts out the code within `ExpandableRelativeLayout` into a class `ExpandableLayoutDelegate` which allows the code to be shared between different ViewGroups without having to duplicate code in each class. None of the functionality or code was really changed, just moved into the new class, with each existing method delegating its calls to this delegate. 

This allowed me to easily create `ExpandableLinearLayout` and `ExpandableFrameLayout` both of which I have added to sample activities, with the first getting its own activity and the other replacing `ExpandableRelativeLayout` in the last RecyclerView example. 

When creating `ExpandableLinearLayout`, I had a method name collision with `setOrientation`, so I had to rename it to `setExpanseOrientation`, which I carried forward to the other view groups, and went ahead and deprecated `setOrientation` in the `ExpandableRelativeLayout` to make the API consistent. 

It looks like a big diff with around 1000 additions, but really none of the code changed, just was moved around for convenience. 

Let me know what you think!
