### PR TITLE
Deprecated init layout

### DIFF
--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayout.java
@@ -77,8 +77,12 @@ public interface ExpandableLayout {
     /**
      * Initializes this layout.
      *
-     * @param isMaintain The state of expanse is maintained if you set true.
+     * This method doesn't work in the {@link ExpandableRelativeLayout}.
+     * You should use the {@link ExpandableLinearLayout} if size of children change.
+     *
+     * @param isMaintain #Notice Not support this argument.
      */
+    @Deprecated
     void initLayout(final boolean isMaintain);
 
     /**

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
@@ -245,11 +245,11 @@ public class ExpandableLinearLayout extends LinearLayout implements ExpandableLa
     public void initLayout(final boolean isMaintain) {
         closePosition = 0;
         layoutSize = 0;
-        isArranged = isMaintain;
+        isArranged = false;
         isCalculatedSize = false;
         savedState = null;
 
-        super.requestLayout();
+        requestLayout();
     }
 
     /**

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
@@ -23,17 +23,23 @@ import java.util.List;
 public class ExpandableLinearLayout extends LinearLayout implements ExpandableLayout {
 
     private int duration;
-    private boolean isExpanded;
     private TimeInterpolator interpolator = new LinearInterpolator();
     /**
-     * You cannot define {@link #isExpanded}, {@link #defaultChildIndex}
+     * Default state of expanse
+     *
+     * @see #defaultChildIndex
+     * @see #defaultPosition
+     */
+    private boolean defaultExpanded;
+    /**
+     * You cannot define {@link #defaultExpanded}, {@link #defaultChildIndex}
      * and {@link #defaultPosition} at the same time.
-     * {@link #defaultPosition} has priority over {@link #isExpanded}
+     * {@link #defaultPosition} has priority over {@link #defaultExpanded}
      * and {@link #defaultChildIndex} if you set them at the same time.
      * <p/>
      * <p/>
      * Priority
-     * {@link #defaultPosition} > {@link #defaultChildIndex} > {@link #isExpanded}
+     * {@link #defaultPosition} > {@link #defaultChildIndex} > {@link #defaultExpanded}
      */
     private int defaultChildIndex;
     private int defaultPosition;
@@ -45,6 +51,7 @@ public class ExpandableLinearLayout extends LinearLayout implements ExpandableLa
 
     private ExpandableLayoutListener listener;
     private ExpandableSavedState savedState;
+    private boolean isExpanded;
     private int layoutSize = 0;
     private boolean isArranged = false;
     private boolean isCalculatedSize = false;
@@ -80,7 +87,7 @@ public class ExpandableLinearLayout extends LinearLayout implements ExpandableLa
         final TypedArray a = context.obtainStyledAttributes(
                 attrs, R.styleable.expandableLayout, defStyleAttr, 0);
         duration = a.getInteger(R.styleable.expandableLayout_ael_duration, DEFAULT_DURATION);
-        isExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
+        defaultExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
         defaultChildIndex = a.getInteger(R.styleable.expandableLayout_ael_defaultChildIndex,
                 Integer.MAX_VALUE);
         defaultPosition = a.getDimensionPixelSize(R.styleable.expandableLayout_ael_defaultPosition,
@@ -126,7 +133,7 @@ public class ExpandableLinearLayout extends LinearLayout implements ExpandableLa
         if (isArranged) return;
 
         // adjust default position if a user set a value.
-        if (!isExpanded) {
+        if (!defaultExpanded) {
             setLayoutSize(closePosition);
         }
         final int childNumbers = childSizeList.size();

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
@@ -248,13 +248,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      */
     @Override
     public void initLayout(final boolean isMaintain) {
-        closePosition = 0;
-        layoutSize = 0;
-        isArranged = isMaintain;
-        isCalculatedSize = false;
-        savedState = null;
-
-        super.requestLayout();
+        // Not support in ExpandableRelativeLayout
     }
 
     /**

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
@@ -23,18 +23,24 @@ import java.util.List;
 public class ExpandableRelativeLayout extends RelativeLayout implements ExpandableLayout {
 
     private int duration;
-    private boolean isExpanded;
     private TimeInterpolator interpolator = new LinearInterpolator();
     private int orientation;
     /**
-     * You cannot define {@link #isExpanded}, {@link #defaultChildIndex}
+     * Default state of expanse
+     *
+     * @see #defaultChildIndex
+     * @see #defaultPosition
+     */
+    private boolean defaultExpanded;
+    /**
+     * You cannot define {@link #defaultExpanded}, {@link #defaultChildIndex}
      * and {@link #defaultPosition} at the same time.
-     * {@link #defaultPosition} has priority over {@link #isExpanded}
+     * {@link #defaultPosition} has priority over {@link #defaultExpanded}
      * and {@link #defaultChildIndex} if you set them at the same time.
      * <p/>
      * <p/>
      * Priority
-     * {@link #defaultPosition} > {@link #defaultChildIndex} > {@link #isExpanded}
+     * {@link #defaultPosition} > {@link #defaultChildIndex} > {@link #defaultExpanded}
      */
     private int defaultChildIndex;
     private int defaultPosition;
@@ -46,6 +52,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
 
     private ExpandableLayoutListener listener;
     private ExpandableSavedState savedState;
+    private boolean isExpanded;
     private int layoutSize = 0;
     private boolean isArranged = false;
     private boolean isCalculatedSize = false;
@@ -85,7 +92,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
         final TypedArray a = context.obtainStyledAttributes(
                 attrs, R.styleable.expandableLayout, defStyleAttr, 0);
         duration = a.getInteger(R.styleable.expandableLayout_ael_duration, DEFAULT_DURATION);
-        isExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
+        defaultExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
         orientation = a.getInteger(R.styleable.expandableLayout_ael_orientation, VERTICAL);
         defaultChildIndex = a.getInteger(R.styleable.expandableLayout_ael_defaultChildIndex,
                 Integer.MAX_VALUE);
@@ -131,7 +138,7 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
         }
 
         // adjust default position if a user set a value.
-        if (!isExpanded) {
+        if (!defaultExpanded) {
             setLayoutSize(closePosition);
         }
         final int childNumbers = childSizeList.size();

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableWeightLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableWeightLayout.java
@@ -20,11 +20,12 @@ import android.widget.RelativeLayout;
 public class ExpandableWeightLayout extends RelativeLayout implements ExpandableLayout {
 
     private int duration;
-    private boolean isExpanded;
     private TimeInterpolator interpolator = new LinearInterpolator();
+    private boolean defaultExpanded;
 
     private ExpandableLayoutListener listener;
     private ExpandableSavedState savedState;
+    private boolean isExpanded;
     private float layoutWeight = 0.0f;
     private boolean isArranged = false;
     private boolean isCalculatedSize = false;
@@ -56,7 +57,7 @@ public class ExpandableWeightLayout extends RelativeLayout implements Expandable
         final TypedArray a = context.obtainStyledAttributes(
                 attrs, R.styleable.expandableLayout, defStyleAttr, 0);
         duration = a.getInteger(R.styleable.expandableLayout_ael_duration, DEFAULT_DURATION);
-        isExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
+        defaultExpanded = a.getBoolean(R.styleable.expandableLayout_ael_expanded, DEFAULT_EXPANDED);
         final int interpolatorType = a.getInteger(R.styleable.expandableLayout_ael_interpolator,
                 Utils.LINEAR_INTERPOLATOR);
         interpolator = Utils.createInterpolator(interpolatorType);
@@ -85,7 +86,7 @@ public class ExpandableWeightLayout extends RelativeLayout implements Expandable
         }
 
         if (isArranged) return;
-        setWeight(isExpanded ? layoutWeight : 0);
+        setWeight(defaultExpanded ? layoutWeight : 0);
         isArranged = true;
 
         if (savedState == null) return;


### PR DESCRIPTION
The initLayout() doesn't work in the ExpandableRelativeLayout.
You should use the ExpandableLinearLayout if the layout size changes.
