### PR TITLE
Fix init layout

### DIFF
--- a/library-ui-test/build.gradle
+++ b/library-ui-test/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     compile "com.android.support:appcompat-v7:$SUPPORT_APP_COMPAT_VERSION"
     compile "com.android.support:recyclerview-v7:$SUPPORT_APP_COMPAT_VERSION"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+    compile 'io.reactivex:rxjava:1.1.6'
+    compile 'io.reactivex:rxandroid:1.2.1'
     androidTestCompile "com.android.support:support-annotations:$SUPPORT_APP_COMPAT_VERSION"
     androidTestCompile "com.android.support.test:runner:$SUPPORT_TEST_VERSION"
     androidTestCompile "com.android.support.test:rules:$SUPPORT_TEST_VERSION"

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest.kt
@@ -43,7 +43,7 @@ class ExpandableLinearLayoutActivityTest : ActivityInstrumentationTestCase2<Expa
     }
 
     @Test
-    fun testExpandableRelativeLayout() {
+    fun testExpandableLinearLayoutActivity() {
         val activity = activity
         val instrumentation = instrumentation
 

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest2.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest2.kt
@@ -44,7 +44,7 @@ class ExpandableLinearLayoutActivityTest2 : ActivityInstrumentationTestCase2<Exp
     }
 
     @Test
-    fun testExpandableRelativeLayout() {
+    fun testExpandableLinearLayoutActivity2() {
         val activity = activity
         val instrumentation = instrumentation
 

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest3.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest3.kt
@@ -49,7 +49,7 @@ class ExpandableLinearLayoutActivityTest3 : ActivityInstrumentationTestCase2<Exp
     }
 
     @Test
-    fun testExpandableRelativeLayout() {
+    fun testExpandableLinearLayoutActivity3() {
         val activity = activity
         val instrumentation = instrumentation
 

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest3.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivityTest3.kt
@@ -1,0 +1,107 @@
+package com.github.aakira.expandablelayout.uitest
+
+import android.app.Activity
+import android.support.test.InstrumentationRegistry
+import android.support.test.espresso.Espresso
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.runner.AndroidJUnit4
+import android.test.ActivityInstrumentationTestCase2
+import android.widget.TextView
+import com.github.aakira.expandablelayout.ExpandableLinearLayout
+import com.github.aakira.expandablelayout.uitest.utils.ElapsedIdLingResource
+import com.github.aakira.expandablelayout.uitest.utils.equalHeight
+import com.github.aakira.expandablelayout.uitest.utils.orMoreHeight
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsNull.notNullValue
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.hamcrest.CoreMatchers.`is` as _is
+
+/**
+ * test for [com.github.aakira.expandablelayout.ExpandableLinearLayout#initlayout]
+ *
+ * The default value is  {@link android.view.animation.AccelerateDecelerateInterpolator}
+ *
+ */
+@RunWith(AndroidJUnit4::class)
+class ExpandableLinearLayoutActivityTest3 : ActivityInstrumentationTestCase2<ExpandableLinearLayoutActivity3>
+(ExpandableLinearLayoutActivity3::class.java) {
+
+    companion object {
+        val DURATION = 300L
+    }
+
+    @Before
+    @Throws(Exception::class)
+    public override fun setUp() {
+        super.setUp()
+        injectInstrumentation(InstrumentationRegistry.getInstrumentation())
+    }
+
+    @After
+    @Throws(Exception::class)
+    public override fun tearDown() {
+        super.tearDown()
+    }
+
+    @Test
+    fun testExpandableRelativeLayout() {
+        val activity = activity
+        val instrumentation = instrumentation
+
+        // check activity
+        assertThat<Activity>(activity, notNullValue())
+        assertThat(instrumentation, notNullValue())
+
+        val expandableLayout = activity.findViewById(R.id.expandableLayout) as ExpandableLinearLayout
+        val child1 = activity.findViewById(R.id.child1) as TextView
+        val child2 = activity.findViewById(R.id.child2) as TextView
+        val marginSmall = getActivity().resources.getDimensionPixelSize(R.dimen.margin_small)
+
+        // default close
+        onView(withId(R.id.expandableLayout)).check(matches(equalHeight(0)))
+
+        // open toggle
+        instrumentation.runOnMainSync { expandableLayout.toggle() }
+        var idlingResource = ElapsedIdLingResource(DURATION)
+        Espresso.registerIdlingResources(idlingResource)
+        onView(withId(R.id.expandableLayout)).check(matches(orMoreHeight(1)))
+        Espresso.unregisterIdlingResources(idlingResource)
+
+        // move to first layout
+        instrumentation.runOnMainSync { expandableLayout.moveChild(0) }
+        idlingResource = ElapsedIdLingResource(DURATION)
+        Espresso.registerIdlingResources(idlingResource)
+        onView(withId(R.id.expandableLayout)).check(matches(equalHeight(
+                child1,
+                margin = marginSmall
+        )))
+        Espresso.unregisterIdlingResources(idlingResource)
+
+        // change child size
+        instrumentation.runOnMainSync {
+            child1.text = "++++++++++++++++++++check_init_layout++++++++++++++++++++++++++++" +
+                    "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+            expandableLayout.initLayout()
+        }
+        idlingResource = ElapsedIdLingResource(DURATION)
+        Espresso.registerIdlingResources(idlingResource)
+        onView(withId(R.id.expandableLayout)).check(matches(equalHeight(0)))
+        Espresso.unregisterIdlingResources(idlingResource)
+
+        // check init layout
+        instrumentation.runOnMainSync { expandableLayout.expand() }
+        idlingResource = ElapsedIdLingResource(DURATION)
+        Espresso.registerIdlingResources(idlingResource)
+        onView(withId(R.id.expandableLayout)).check(matches(equalHeight(
+                child1,
+                child2,
+                margin = marginSmall
+        )))
+        Espresso.unregisterIdlingResources(idlingResource)
+    }
+}

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRecyclerViewActivityTest.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRecyclerViewActivityTest.kt
@@ -45,7 +45,7 @@ class ExpandableRecyclerViewActivityTest : ActivityInstrumentationTestCase2<Expa
     }
 
     @Test
-    fun testExpandableRecyclerView() {
+    fun testExpandableRecyclerViewActivity() {
         val activity = activity
         val instrumentation = instrumentation
 

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRelativeLayoutActivityTest.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRelativeLayoutActivityTest.kt
@@ -43,7 +43,7 @@ class ExpandableRelativeLayoutActivityTest : ActivityInstrumentationTestCase2<Ex
     }
 
     @Test
-    fun testExpandableRelativeLayout() {
+    fun testExpandableRelativeLayoutActivity() {
         val activity = activity
         val instrumentation = instrumentation
 

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRelativeLayoutActivityTest2.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRelativeLayoutActivityTest2.kt
@@ -43,7 +43,7 @@ class ExpandableRelativeLayoutActivityTest2 : ActivityInstrumentationTestCase2<E
     }
 
     @Test
-    fun testExpandableRelativeLayout2() {
+    fun testExpandableRelativeLayoutActivity2() {
         val activity = activity
         val instrumentation = instrumentation
         val resources = activity.resources

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRelativeLayoutActivityTest3.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableRelativeLayoutActivityTest3.kt
@@ -43,7 +43,7 @@ class ExpandableRelativeLayoutActivityTest3 : ActivityInstrumentationTestCase2<E
     }
 
     @Test
-    fun testExpandableRelativeLayout3() {
+    fun testExpandableRelativeLayoutActivity3() {
         val activity = activity
         val instrumentation = instrumentation
 

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableWeightLayoutActivityTest.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/ExpandableWeightLayoutActivityTest.kt
@@ -25,7 +25,7 @@ class ExpandableWeightLayoutActivityTest : ActivityInstrumentationTestCase2<Expa
 (ExpandableWeightLayoutActivity::class.java) {
 
     companion object {
-        val DURATION = 350L
+        val DURATION = 1000L
     }
 
     @Before
@@ -42,7 +42,7 @@ class ExpandableWeightLayoutActivityTest : ActivityInstrumentationTestCase2<Expa
     }
 
     @Test
-    fun testExpandableRelativeLayout3() {
+    fun testExpandableWeightLayout() {
         val activity = activity
         val instrumentation = instrumentation
 
@@ -90,9 +90,20 @@ class ExpandableWeightLayoutActivityTest : ActivityInstrumentationTestCase2<Expa
 
         // set expanse (default expanse weight is 3)
         instrumentation.runOnMainSync { expandableLayout.isExpanded = true }
-        idlingResource = ElapsedIdLingResource(1000)
+        idlingResource = ElapsedIdLingResource(DURATION)
         Espresso.registerIdlingResources(idlingResource)
         onView(withId(R.id.expandableLayout)).check(matches(equalWeight(3f)))
+        Espresso.unregisterIdlingResources(idlingResource)
+        assertThat(expandableLayout.isExpanded, _is(true))
+
+        // check init layout
+        instrumentation.runOnMainSync {
+            expandableLayout.setExpandWeight(10f)
+            expandableLayout.expand()
+        }
+        idlingResource = ElapsedIdLingResource(DURATION)
+        Espresso.registerIdlingResources(idlingResource)
+        onView(withId(R.id.expandableLayout)).check(matches(equalWeight(10f)))
         Espresso.unregisterIdlingResources(idlingResource)
         assertThat(expandableLayout.isExpanded, _is(true))
     }

--- a/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/utils/ViewTestUtil.kt
+++ b/library-ui-test/src/androidTest/java/com/github/aakira/expandablelayout/uitest/utils/ViewTestUtil.kt
@@ -55,11 +55,18 @@ fun equalWidth(width: Int) = object : TypeSafeMatcher<View>() {
 }
 
 fun equalWeight(weight: Float) = object : TypeSafeMatcher<View>() {
+    var viewWeight = 0f
+
     override fun describeTo(description: Description) {
-        description.appendText(String.format("The weight of this layout " +
-                "is not equal to weight(%f).", weight))
+        description.appendText(String.format("The weight(%f) of this layout " +
+                "is not equal to weight(%f).", viewWeight, weight))
     }
 
-    override fun matchesSafely(view: View) =
-            (view.layoutParams as LinearLayout.LayoutParams).weight == weight
+    override fun matchesSafely(view: View): Boolean {
+        (view.layoutParams as LinearLayout.LayoutParams).apply {
+            viewWeight = weight
+        }.run {
+            return (view.layoutParams as LinearLayout.LayoutParams).weight == weight
+        }
+    }
 }

--- a/library-ui-test/src/main/AndroidManifest.xml
+++ b/library-ui-test/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         </activity>
 
         <activity android:name=".ExpandableLinearLayoutActivity"/>
+        <activity android:name=".ExpandableLinearLayoutActivity3"/>
         <activity android:name=".ExpandableRecyclerViewActivity"/>
         <activity android:name=".ExpandableRelativeLayoutActivity"/>
         <activity android:name=".ExpandableRelativeLayoutActivity2"/>

--- a/library-ui-test/src/main/kotlin/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivity3.kt
+++ b/library-ui-test/src/main/kotlin/com/github/aakira/expandablelayout/uitest/ExpandableLinearLayoutActivity3.kt
@@ -2,15 +2,8 @@ package com.github.aakira.expandablelayout.uitest
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.util.Log
-import android.view.ViewGroup
-import android.widget.LinearLayout
-import android.widget.TextView
 import com.github.aakira.expandablelayout.ExpandableLinearLayout
-import rx.Observable
-import rx.android.schedulers.AndroidSchedulers
 import rx.subscriptions.CompositeSubscription
-import java.util.concurrent.TimeUnit
 import kotlin.properties.Delegates
 
 /**
@@ -34,13 +27,11 @@ class ExpandableLinearLayoutActivity3 : AppCompatActivity() {
         findViewById(R.id.moveChildButton)?.setOnClickListener { expandableLayout.moveChild(0) }
         findViewById(R.id.moveChildButton2)?.setOnClickListener { expandableLayout.moveChild(1) }
 
-        val child1 = findViewById(R.id.child1) as TextView
-        subscriptions.add(Observable.timer(5, TimeUnit.SECONDS)
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe {
-
-
-                    Log.v("hoge", "hoge")
+        // uncomment if you want to check the #ExpandableLayout.initLayout()
+//        val child1 = findViewById(R.id.child1) as TextView
+//        subscriptions.add(Observable.timer(5, TimeUnit.SECONDS)
+//                .observeOn(AndroidSchedulers.mainThread())
+//                .subscribe {
 //                    child1.text =
 //                            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
 //                                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
@@ -49,18 +40,7 @@ class ExpandableLinearLayoutActivity3 : AppCompatActivity() {
 //                                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 //                    expandableLayout.initLayout()
 //                    expandableLayout.expand(0, null)
-
-                    val child2 = TextView(this)
-                    child2.text =
-                            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
-                                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
-                                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
-                                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
-                                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                    expandableLayout.addView(child2, LinearLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
-//                    expandableLayout.expand()
-                })
+//                })
     }
 
     override fun onDestroy() {

--- a/library-ui-test/src/main/res/layout/activity_expandable_linear_layout3.xml
+++ b/library-ui-test/src/main/res/layout/activity_expandable_linear_layout3.xml
@@ -65,7 +65,6 @@
             android:textColor="@color/white"
         />
 
-
         <TextView
             android:id="@+id/child2"
             android:layout_width="match_parent"
@@ -76,6 +75,5 @@
             android:text="sample.sample.sample.sample.sample.sample.sample.sample.sample.sample."
             android:textColor="@color/white"
         />
-
     </com.github.aakira.expandablelayout.ExpandableLinearLayout>
 </LinearLayout>

--- a/library-ui-test/src/main/res/layout/activity_expandable_weight_layout.xml
+++ b/library-ui-test/src/main/res/layout/activity_expandable_weight_layout.xml
@@ -25,13 +25,15 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        >
 
         <View
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:background="@color/material_teal_500"></View>
+            android:background="@color/material_teal_500"
+            />
 
         <com.github.aakira.expandablelayout.ExpandableWeightLayout
             android:id="@+id/expandableLayout"
@@ -42,26 +44,30 @@
             android:padding="@dimen/margin_normal"
             app:ael_duration="1000"
             app:ael_expanded="false"
-            app:ael_interpolator="anticipateOvershoot">
+            app:ael_interpolator="anticipateOvershoot"
+            >
 
             <TextView
+                android:id="@+id/child1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="
-    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
-    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
-    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
-    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
-    sample.sample.sample.sample.sample.sample.sample.sample.sample.sample.\n
-    "
                 android:gravity="center"
-                android:textColor="#eee"/>
+                android:text="
+                    sample1.sample1.sample1.sample1.sample1.sample1.sample1.sample1.sample1.sample1.\n
+                    sample2.sample2.sample2.sample2.sample2.sample2.sample2.sample2.sample2.sample2.\n
+                    sample3.sample3.sample3.sample3.sample3.sample3.sample3.sample3.sample3.sample3.\n
+                    sample4.sample4.sample4.sample4.sample4.sample4.sample4.sample4.sample4.sample4.\n
+                    sample5.sample5.sample5.sample5.sample5.sample5.sample5.sample5.sample5.sample5.\n
+                    "
+                android:textColor="#eee"
+                />
         </com.github.aakira.expandablelayout.ExpandableWeightLayout>
 
         <View
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:background="@color/material_teal_700"></View>
+            android:background="@color/material_teal_700"
+            />
     </LinearLayout>
 </LinearLayout>

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLayout.java
@@ -75,17 +75,6 @@ public interface ExpandableLayout {
     void collapse(final long duration, @Nullable final TimeInterpolator interpolator);
 
     /**
-     * Initializes this layout.
-     *
-     * This method doesn't work in the {@link ExpandableRelativeLayout}.
-     * You should use the {@link ExpandableLinearLayout} if size of children change.
-     *
-     * @param isMaintain #Notice Not support this argument.
-     */
-    @Deprecated
-    void initLayout(final boolean isMaintain);
-
-    /**
      * Sets the expandable layout listener.
      *
      * @param listener ExpandableLayoutListener

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableLinearLayout.java
@@ -258,20 +258,6 @@ public class ExpandableLinearLayout extends LinearLayout implements ExpandableLa
      * {@inheritDoc}
      */
     @Override
-    public void initLayout(final boolean isMaintain) {
-        closePosition = 0;
-        layoutSize = 0;
-        isArranged = false;
-        isCalculatedSize = false;
-        savedState = null;
-
-        requestLayout();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void setDuration(final int duration) {
         if (duration < 0) {
             throw new IllegalArgumentException("Animators cannot have negative duration: " +
@@ -310,6 +296,25 @@ public class ExpandableLinearLayout extends LinearLayout implements ExpandableLa
     @Override
     public void setInterpolator(@NonNull final TimeInterpolator interpolator) {
         this.interpolator = interpolator;
+    }
+
+    /**
+     * Initializes this layout.
+     */
+    public void initLayout() {
+        closePosition = 0;
+        layoutSize = 0;
+        isArranged = false;
+        isCalculatedSize = false;
+        savedState = null;
+
+        if (isVertical()) {
+            measure(MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.UNSPECIFIED));
+        } else {
+            measure(MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.UNSPECIFIED),
+                    MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+        }
     }
 
     /**

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableRelativeLayout.java
@@ -255,14 +255,6 @@ public class ExpandableRelativeLayout extends RelativeLayout implements Expandab
      * {@inheritDoc}
      */
     @Override
-    public void initLayout(final boolean isMaintain) {
-        // Not support in ExpandableRelativeLayout
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void setDuration(final int duration) {
         if (duration < 0) {
             throw new IllegalArgumentException("Animators cannot have negative duration: " +

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableWeightLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableWeightLayout.java
@@ -200,19 +200,6 @@ public class ExpandableWeightLayout extends RelativeLayout implements Expandable
      * {@inheritDoc}
      */
     @Override
-    public void initLayout(final boolean isMaintain) {
-        layoutWeight = 0;
-        isArranged = isMaintain;
-        isCalculatedSize = false;
-        savedState = null;
-
-        super.requestLayout();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void setDuration(@NonNull final int duration) {
         if (duration < 0) {
             throw new IllegalArgumentException("Animators cannot have negative duration: " +

--- a/library/src/main/java/com/github/aakira/expandablelayout/ExpandableWeightLayout.java
+++ b/library/src/main/java/com/github/aakira/expandablelayout/ExpandableWeightLayout.java
@@ -239,6 +239,15 @@ public class ExpandableWeightLayout extends RelativeLayout implements Expandable
     }
 
     /**
+     * Sets weight of expandable layout.
+     *
+     * @param expandWeight expand to this weight by {@link #expand()}
+     */
+    public void setExpandWeight(final float expandWeight) {
+        layoutWeight = expandWeight;
+    }
+
+    /**
      * Gets current weight of expandable layout.
      *
      * @return weight


### PR DESCRIPTION
You have to call `ExpandableLinarLayout.initLayout()` if container size is changed.
- Notice
  `ExpandableRelativeLayout` doesn't have this method.
  You should use the ExpandableLinearLayout if container size is changed.

Fix #84
Close #66
